### PR TITLE
Formats Parsing Order

### DIFF
--- a/lib/doc.js
+++ b/lib/doc.js
@@ -1,4 +1,5 @@
 var dom = require('./dom');
+var intersection = require('lodash.intersection');
 
 module.exports = Doc;
 
@@ -7,6 +8,7 @@ function Doc(formats, options) {
   this.document = options.document;
   this.blockTag = options && options.blockTag || 'div';
   this.inlineTag = options && options.inlineTag || 'span';
+  this.formatOrder = options && options.formatOrder || Object.keys(this.formats);
   this.root = this.document.createElement('div');
 }
 
@@ -51,15 +53,13 @@ Doc.prototype.writeText = function(text, attrs) {
 
   this.line.appendChild(node);
 
-  // TODO: loop through in priority order
   // TODO: each format function returns a promise
-  for (var key in attrs) {
-    if (!attrs.hasOwnProperty(key)) { continue }
-    var format = this.formats[key];
+  intersection(this.formatOrder, Object.keys(attrs)).forEach(name => {
+    var format = this.formats[name];
     if (format && format.type !== 'line') {
-      node = this.applyFormat(node, format, attrs[key]);
+      node = this.applyFormat(node, format, attrs[name]);
     }
-  }
+  });
 
   // TODO: optimize line?
   this.line = this.root.lastChild;
@@ -119,15 +119,13 @@ Doc.prototype.applyFormat = function(node, format, value) {
 Doc.prototype.formatLine = function(attrs) {
   var line = this.line;
 
-  // TODO: loop through in priority order
   // TODO: each format function returns a promise
-  for (var name in attrs) {
-    if (!attrs.hasOwnProperty(name)) { continue }
+  intersection(this.formatOrder, Object.keys(attrs)).forEach(name => {
     var format = this.formats[name];
     if (format && format.type === 'line') {
       line = this.applyFormat(line, format, attrs[name]);
     }
-  }
+  });
 
   this.line = line;
 };

--- a/lib/doc.js
+++ b/lib/doc.js
@@ -1,5 +1,5 @@
 var dom = require('./dom');
-var intersection = require('lodash.intersection');
+var intersection = require('lodash').intersection;
 
 module.exports = Doc;
 
@@ -54,10 +54,11 @@ Doc.prototype.writeText = function(text, attrs) {
   this.line.appendChild(node);
 
   // TODO: each format function returns a promise
-  intersection(this.formatOrder, Object.keys(attrs)).forEach(name => {
-    var format = this.formats[name];
+  var self = this;
+  intersection(this.formatOrder, Object.keys(attrs)).forEach(function(name) {
+    var format = self.formats[name];
     if (format && format.type !== 'line') {
-      node = this.applyFormat(node, format, attrs[name]);
+      node = self.applyFormat(node, format, attrs[name]);
     }
   });
 
@@ -120,10 +121,11 @@ Doc.prototype.formatLine = function(attrs) {
   var line = this.line;
 
   // TODO: each format function returns a promise
-  intersection(this.formatOrder, Object.keys(attrs)).forEach(name => {
-    var format = this.formats[name];
+  var self = this;
+  intersection(this.formatOrder, Object.keys(attrs)).forEach(function(name) {
+    var format = self.formats[name];
     if (format && format.type === 'line') {
-      line = this.applyFormat(line, format, attrs[name]);
+      line = self.applyFormat(line, format, attrs[name]);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/thomsbg/convert-rich-text",
   "dependencies": {
-    "jsdom": ">=3.1.2"
+    "jsdom": ">=3.1.2",
+    "lodash.intersection": "^4.4.0"
   },
   "devDependencies": {
     "browserify": "^9.0.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/thomsbg/convert-rich-text",
   "dependencies": {
     "jsdom": ">=3.1.2",
-    "lodash.intersection": "^4.4.0"
+    "lodash": "^3.6.0"
   },
   "devDependencies": {
     "browserify": "^9.0.8",


### PR DESCRIPTION
Uses `lodash#intersection` to ensure formats are applied in a specific order when processing an `op.attributes`. This order is either generated non-deterministically via `Object.keys(this.formats)`, or can be explicitly passed in as an option.
