### PR TITLE
Dom.switchTag should always return `this`

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -120,7 +120,7 @@ dom.prototype.replaceWith = function(newNode) {
 
 dom.prototype.switchTag = function(newTag) {
   newTag = newTag.toUpperCase();
-  if (this.node.tagName === newTag) { return this.node; }
+  if (this.node.tagName === newTag) { return this; }
   var newNode = this.document.createElement(newTag);
   var attributes = this.attributes();
   if (!dom.VOID_TAGS[newTag]) { this.moveChildren(newNode); }


### PR DESCRIPTION
When `Dom.switchTag` is called on a node with the expected tag already in place, the return of `this.node` causes subsequent `get()` calls to fail.

Specifically, this bug crops up [here](https://github.com/voxmedia/convert-rich-text/blob/bc-switch-tag-fix/lib/doc.js#L72).