### PR TITLE
Refactor dom lib to match what's used in quill

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -198,12 +198,14 @@ dom.prototype.text = function(text) {
   }
 };
 
-dom.prototype.wrap = function(tag) {
-  var wrapper = this.document.createElement(tag);
+dom.prototype.wrap = function(wrapper) {
   if (this.node.parentNode) {
     this.node.parentNode.insertBefore(wrapper, this.node);
   }
-  wrapper.appendChild(this.node);
-  this.node = wrapper;
+  var parent = wrapper;
+  while (parent.firstChild) {
+    parent = parent.firstChild;
+  }
+  parent.appendChild(this.node);
   return this;
 };

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -4,7 +4,6 @@ var dom = module.exports = function(node) {
   }
 
   this.node = node;
-  this.document = node.ownerDocument;
 };
 
 dom.ELEMENT_NODE = 1;
@@ -121,7 +120,7 @@ dom.prototype.replaceWith = function(newNode) {
 dom.prototype.switchTag = function(newTag) {
   newTag = newTag.toUpperCase();
   if (this.node.tagName === newTag) { return this; }
-  var newNode = this.document.createElement(newTag);
+  var newNode = this.node.ownerDocument.createElement(newTag);
   var attributes = this.attributes();
   if (!dom.VOID_TAGS[newTag]) { this.moveChildren(newNode); }
   this.replaceWith(newNode);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -33,6 +33,44 @@ dom.EMBED_TAGS = {
   IFRAME: true,
   IMG: true
 };
+dom.BLOCK_TAGS = {
+  ADDRESS: true,
+  ARTICLE: true,
+  ASIDE: true,
+  AUDIO: true,
+  BLOCKQUOTE: true,
+  CANVAS: true,
+  DD: true,
+  DIV: true,
+  DL: true,
+  FIGCAPTION: true,
+  FIGURE: true,
+  FOOTER: true,
+  FORM: true,
+  H1: true,
+  H2: true,
+  H3: true,
+  H4: true,
+  H5: true,
+  H6: true,
+  HEADER: true,
+  HGROUP: true,
+  LI: true,
+  OL: true,
+  OUTPUT: true,
+  P: true,
+  PRE: true,
+  SECTION: true,
+  TABLE: true,
+  TBODY: true,
+  TD: true,
+  TFOOT: true,
+  TH: true,
+  THEAD: true,
+  TR: true,
+  UL: true,
+  VIDEO: true
+}
 
 dom.prototype.attributes = function(attributes) {
   if (attributes) {


### PR DESCRIPTION
- Use `node.ownerDocument` instead of `dom(node).document`
- The argument to `wrap()` is an element tree, not a tag name.