### PR TITLE
Updating class name for drop caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,15 @@ attribute-, class- and style-based formats wrap text with an inline element if t
 You can change these tags with the `blockTag` and `inlineTag` options:
 
 ```javascript
-convert(delta, formats, { blockTag: 'FIGURE', inlineTag: 'INS' });
+convert.toHtml(delta, formats, { blockTag: 'FIGURE', inlineTag: 'INS' });
 ```
 
 ## Changelog
 
+- `5.0.0` Move opinionated export formats from content-api to convert-rich-text.
+- `4.0.0` Bump node version requirements, update object format to match Quill, move repo to voxmedia fork
+- `3.0.0` Update jsdom version
+- `2.0.3` Update `parentTag` logic
 - `2.0.2` [Relax jsdom and node version requirements]
 - `2.0.0` [Server-side support via jsdom](https://github.com/thomsbg/convert-rich-text/pull/2), node version locked to <=0.12
 - `1.2.1` Beginning of changelog

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ attribute-, class- and style-based formats wrap text with an inline element if t
 You can change these tags with the `blockTag` and `inlineTag` options:
 
 ```javascript
-convert.toHtml(delta, formats, { blockTag: 'FIGURE', inlineTag: 'INS' });
+convert(delta, formats, { blockTag: 'FIGURE', inlineTag: 'INS' });
 ```
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ convert.toHtml(delta, formats, { blockTag: 'FIGURE', inlineTag: 'INS' });
 
 ## Changelog
 
+- `5.0.1` Update to rendered `class` names for drop caps
 - `5.0.0` Move opinionated export formats from content-api to convert-rich-text.
 - `4.0.0` Bump node version requirements, update object format to match Quill, move repo to voxmedia fork
 - `3.0.0` Update jsdom version

--- a/lib/formats/dropcap.js
+++ b/lib/formats/dropcap.js
@@ -21,8 +21,7 @@ exports.public = {
   type: 'line',
   add: function(node, value) {
     if (value) {
-      node.classList.add('p-dropcap');
-      node.classList.add('has-dropcap');
+      node.classList.add('p--has-dropcap');
     }
 
     return node;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-rich-text",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Convert an insert-only rich-text delta into HTML",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
Hi, friends, hi, hello. Per https://github.com/voxmedia/sbn/pull/8572, we’re looking to change the class name for drop caps from this:

```
<p class="p-dropcap has-dropcap">…</p>
```

to this:

```
<p class="p--has-dropcap">
```

I’ll spare you _all_ the background (https://github.com/voxmedia/sbn/pull/8572 has Homeric levels of detail, if you’re interested) (and I’m of course happy to answer any questions here, if I can!), but basically: this will allow us to resolve a number of layout-related inconsistencies; improve the accessibility of those newer drop caps; and _also_ provide a clean break from our “old” drop caps.

If you have any feedback, questions, or comments, please let me know. And thank you for your time!

(**Note:** There’s probably a timing-related issue to discuss here, in terms of syncing up this update with the https://github.com/voxmedia/sbn/pull/8572 merge—if you have any preferred ways of handling that, let me know!)