### PR TITLE
Add tools component

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ convert(delta, formats, { blockTag: 'FIGURE', inlineTag: 'INS' });
 
 ## Changelog
 
+- `5.2.0` Adds Tools component for This Old House
 - `5.1.0` Adds Project Details component for This Old House
 - `5.0.1` Update to rendered `class` names for drop caps
 - `5.0.0` Move opinionated export formats from content-api to convert-rich-text.

--- a/lib/formats/index.js
+++ b/lib/formats/index.js
@@ -40,6 +40,7 @@ function makeFormats(type) {
     newsletter: require('./newsletter')[type],
     credits: require('./credits')[type],
     toh_project_details: require('./toh_project_details')[type],
+    toh_tools: require('./toh_tools')[type],
   };
 }
 
@@ -73,6 +74,7 @@ exports.options = {
     'readmore',
     'video',
     'toh_project_details',
+    'toh_tools',
 
     // line: wrapper tag
     'position',

--- a/lib/formats/object.js
+++ b/lib/formats/object.js
@@ -8,7 +8,8 @@ var USE_FIXED_HEIGHT = [
   'ratingcard',
   'video',
   'hr',
-  'toh_project_details'
+  'toh_project_details',
+  'toh_tools'
 ];
 
 module.exports = function(type) {

--- a/lib/formats/toh_tools.js
+++ b/lib/formats/toh_tools.js
@@ -3,7 +3,7 @@ exports.public = {
     dom(node.parentNode).switchTag('ASIDE');
 
     var data = {
-      stories: value.map(function(item) {
+      tools: value.map(function(item) {
         return {
           caption: item.caption,
           url: item.url,

--- a/lib/formats/toh_tools.js
+++ b/lib/formats/toh_tools.js
@@ -1,0 +1,24 @@
+exports.public = {
+  add: function(node, value, dom) {
+    dom(node.parentNode).switchTag('ASIDE');
+
+    var data = {
+      stories: value.map(function(item) {
+        return {
+          caption: item.caption,
+          url: item.url,
+          chorus_asset_id: item.image.id
+        };
+      })
+    };
+
+    var div = node.ownerDocument.createElement('div');
+    div.setAttribute('data-anthem-component', 'toh_tools');
+    div.setAttribute('data-anthem-component-data', JSON.stringify(data));
+    dom(node).replace(div);
+
+    return div;
+  }
+};
+
+exports.private = require('./object')('toh_tools');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-rich-text",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Convert an insert-only rich-text delta into HTML",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
Adds the Tools component to convert-rich-text

Jira epic: https://vmproduct.atlassian.net/browse/TOH-170
Jira ticket: https://vmproduct.atlassian.net/browse/TOH-179
Tech plan: https://docs.google.com/document/d/1NI4iDZrjqvo6vcObK_mCF3v3vPV3RpCC8z3KTR1uJuc/edit#

Launch plan:

- Merge voxmedia/convert-rich-text#11 and publish to npm
- Update package.json to point to the new version in voxmedia/content-api#528 & voxmedia/anthem#6744
- Deploy voxmedia/sbn#9752
- Deploy voxmedia/content-api#528
- Deploy voxmedia/anthem#6744