### PR TITLE
CBEAT-81 - Add pym.js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ convert(delta, formats, { blockTag: 'FIGURE', inlineTag: 'INS' });
 
 ## Changelog
 
+- `5.3.0` Adds support for Pym.js component
 - `5.2.0` Adds Tools component for This Old House
 - `5.1.0` Adds Project Details component for This Old House
 - `5.0.1` Update to rendered `class` names for drop caps

--- a/lib/formats/index.js
+++ b/lib/formats/index.js
@@ -41,6 +41,7 @@ function makeFormats(type) {
     credits: require('./credits')[type],
     toh_project_details: require('./toh_project_details')[type],
     toh_tools: require('./toh_tools')[type],
+    pym_js: require('./pym_js')[type]
   };
 }
 
@@ -75,6 +76,7 @@ exports.options = {
     'video',
     'toh_project_details',
     'toh_tools',
+    'pym_js',
 
     // line: wrapper tag
     'position',

--- a/lib/formats/index.js
+++ b/lib/formats/index.js
@@ -41,7 +41,7 @@ function makeFormats(type) {
     credits: require('./credits')[type],
     toh_project_details: require('./toh_project_details')[type],
     toh_tools: require('./toh_tools')[type],
-    pym_js: require('./pym_js')[type]
+    pym: require('./pym')[type]
   };
 }
 

--- a/lib/formats/index.js
+++ b/lib/formats/index.js
@@ -76,7 +76,7 @@ exports.options = {
     'video',
     'toh_project_details',
     'toh_tools',
-    'pym_js',
+    'pym',
 
     // line: wrapper tag
     'position',

--- a/lib/formats/object.js
+++ b/lib/formats/object.js
@@ -10,7 +10,7 @@ var USE_FIXED_HEIGHT = [
   'hr',
   'toh_project_details',
   'toh_tools',
-  'pym_js'
+  'pym'
 ];
 
 module.exports = function(type) {

--- a/lib/formats/object.js
+++ b/lib/formats/object.js
@@ -9,7 +9,8 @@ var USE_FIXED_HEIGHT = [
   'video',
   'hr',
   'toh_project_details',
-  'toh_tools'
+  'toh_tools',
+  'pym_js'
 ];
 
 module.exports = function(type) {

--- a/lib/formats/pym.js
+++ b/lib/formats/pym.js
@@ -7,7 +7,7 @@ exports.public = {
     };
 
     var div = node.ownerDocument.createElement('div');
-    div.setAttribute('data-anthem-component', 'pym_js');
+    div.setAttribute('data-anthem-component', 'pym');
     div.setAttribute('data-anthem-component-data', JSON.stringify(data));
     dom(node).replace(div);
 
@@ -15,4 +15,4 @@ exports.public = {
   }
 };
 
-exports.private = require('./object')('pym_js');
+exports.private = require('./object')('pym');

--- a/lib/formats/pym.js
+++ b/lib/formats/pym.js
@@ -1,0 +1,18 @@
+exports.public = {
+  add: function(node, value, dom) {
+    dom(node.parentNode).switchTag('ASIDE');
+
+    var data = {
+      url: value.url
+    };
+
+    var div = node.ownerDocument.createElement('div');
+    div.setAttribute('data-anthem-component', 'pym_js');
+    div.setAttribute('data-anthem-component-data', JSON.stringify(data));
+    dom(node).replace(div);
+
+    return div;
+  }
+};
+
+exports.private = require('./object')('pym_js');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-rich-text",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Convert an insert-only rich-text delta into HTML",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION
## Purpose

Adds support for the upcoming `pym_js` component for enabling [Pym.js embeds](https://github.com/nprapps/pym.js/).

Tracked by: [CBEAT-81](https://vmproduct.atlassian.net/browse/CBEAT-81)
Epic: [CBEAT-80](https://vmproduct.atlassian.net/browse/CBEAT-80)

## Launch Plan
Merge upon approval, then run `yarn publish` in the container locally. You may need to be added the voxmedia npm org to do this.

Then, when you see the new version available in npm, follow on with:
1) https://github.com/voxmedia/content-api/pull/550
Before merging: update `package.json` and update the convert-rich-text to `"convert-rich-text": "^5.3.0",` and run `yarn install` in a container. Commit both files and push to branch.

2) https://github.com/voxmedia/anthem/pull/6777
Follow similar steps to set the correct version of convert-rich-text.

3) https://github.com/voxmedia/sbn/pull/10127

## Gif (rich text)
![pokemon](https://media.giphy.com/media/HZiuVPPYQLYLC/giphy.gif)